### PR TITLE
Use elasticsearch1 instead of elasticsearch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ before_script:
 
 python:
   - 2.7
-  - 3.3
-  - 3.4
   - 3.6
+  - 3.7
+  - 3.8
   - pypy
 
 install:

--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -10,10 +10,10 @@ from six.moves import xrange
 from six.moves.urllib.parse import urlparse, urlencode, quote_plus
 
 import certifi
-from elasticsearch.connection_pool import RandomSelector
-from elasticsearch.exceptions import (ConnectionError, ConnectionTimeout,
+from elasticsearch1.connection_pool import RandomSelector
+from elasticsearch1.exceptions import (ConnectionError, ConnectionTimeout,
                                       TransportError, SerializationError)
-from elasticsearch.transport import Transport
+from elasticsearch1.transport import Transport
 import simplejson as json  # for use_decimal
 
 from pyelasticsearch.exceptions import (ElasticHttpError,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi
-elasticsearch>=1.3.0,<2.0.0
+elasticsearch1>=1.3.0,<2.0.0
 urllib3>=1.8,<2.0
 simplejson>=3.0
 six>=1.4.0,<2.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py33, py34, py36, pypy
+envlist = py27, py36, py37, py38, pypy
 
 [testenv]
 setenv =


### PR DESCRIPTION
Using elasticsearch1 allows the projects to use pyelasticsearch in
parallel of a recent version elasticsearch-py with ealsticsearch-dsl